### PR TITLE
feat: add support to mongo uri

### DIFF
--- a/backwork/Dockerfile
+++ b/backwork/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-alpine3.9
+FROM python:3.8.6-alpine3.12
 LABEL maintainer="leonsp@ca.ibm.com"
 
 # Install database clients

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
   backwork:
     build:
       context: ./backwork
-    image: bigdatauniversity/portal.gamora:dev
+    image: bigdatauniversity/backwork:1.5.0
     environment:
       - MYSQL_HOST=mysql
       - MYSQL_PORT=3306


### PR DESCRIPTION
also added the `--authenticationDatabase` flag to `montorestore` command, by default it is using the `admin` table.