### PR TITLE
chore(deps): bump python image to 3.10 and backwork upload cos library

### DIFF
--- a/backwork/Dockerfile
+++ b/backwork/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.6-alpine3.12
+FROM python:3.10-alpine
 LABEL maintainer="leonsp@ca.ibm.com"
 
 # Install database clients
@@ -31,6 +31,8 @@ RUN echo 'http://dl-3.alpinelinux.org/alpine/edge/community' >> /etc/apk/reposit
 ##########
 
 COPY requirements.txt ./
+RUN python -m pip install --upgrade pip
+RUN pip install setuptools==57.5.0
 RUN pip install -r ./requirements.txt
 
 COPY ./docker-entrypoint.sh /

--- a/backwork/requirements.txt
+++ b/backwork/requirements.txt
@@ -7,5 +7,5 @@ backwork-backup-mysql==0.3.0
 backwork-backup-postgresql==0.2.1
 backwork-notifier-sentry==0.2.0
 backwork-upload-softlayer==0.2.1
-backwork-upload-cos==0.3.0
+backwork-upload-cos==0.3.1
 backwork-notifier-http==0.1.4


### PR DESCRIPTION
- python 3.10 as base image
- backwork upload cos library bumped to 0.3.1